### PR TITLE
Fix broken Velero package: prefix version string passed to make with a 'v' 

### DIFF
--- a/velero/.SRCINFO
+++ b/velero/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = velero
 	pkgdesc = Backup and migrate Kubernetes applications and their persistent volumes
 	pkgver = 1.6.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://velero.io
 	arch = x86_64
 	arch = armv6h

--- a/velero/PKGBUILD
+++ b/velero/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=velero
 pkgver=1.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Backup and migrate Kubernetes applications and their persistent volumes"
 arch=('x86_64' 'armv6h' 'armv7h' 'aarch64')
 url="https://velero.io"
@@ -30,7 +30,7 @@ build() {
     export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
     export GOLDFLAGS="-linkmode=external"
 
-    make GIT_TREE_STATE=clean VERSION=$pkgver local
+    make GIT_TREE_STATE=clean VERSION=v$pkgver local
 
     ./velero completion bash | install -Dm644 /dev/stdin share/bash-completion/completions/velero
     ./velero completion zsh | install -Dm644 /dev/stdin share/zsh/site-functions/_velero


### PR DESCRIPTION
This PR fixes the version string passed to `make` in the Velero PKGBUILD, which is currently incorrect and results in a broken build.

## Background
The Velero package is currently broken. The version string passed to `make` is incorrect. This results in a broken Velero server install, one which fails with message `Pulling image "velero/velero:1.6.0"`. The tag `1.6.0` does not exist on the Velero docker image, the correct version tag is `v1.6.0`.

Prefixing the version string with a 'v' resolves the issue. I've confirmed this by rebuilding and reinstalling Velero in my Kubernetes cluster. 